### PR TITLE
execute: check for 0 rather than FALSE from mysql_insert_id(…)

### DIFF
--- a/kirby.php
+++ b/kirby.php
@@ -1141,7 +1141,7 @@ class db {
     if(!$execute) return self::error(l::get('db.errors.query_failed', 'The database query failed'));
     
     $last_id = self::last_id();
-    return ($last_id === false) ? self::$affected : self::last_id();
+    return ($last_id === 0) ? self::$affected : self::last_id();
   }
 
   /** 


### PR DESCRIPTION
From the docs:
"The ID generated for an AUTO_INCREMENT column by the previous query on
success, 0 if the previous query does not generate an AUTO_INCREMENT
value, or FALSE if no MySQL connection was established."